### PR TITLE
把 prompt 转成 str()

### DIFF
--- a/games_ai/__init__.py
+++ b/games_ai/__init__.py
@@ -37,7 +37,7 @@ def on_load(server: PluginServerInterface, old):
         "max_history": 10,
         "all_ai": {
             "<Your AI ID>":{
-                "prompt": server.rtr("games_ai.system_message.default"),
+                "prompt": str(server.rtr("games_ai.system_message.default")),
                 "ai_name": "[GamesAI]",
                 "base_url": "<Your API Base URL>",
                 "ai_model": "<Your AI Model>",


### PR DESCRIPTION
今天发现了这个插件，但是发现报错了，当时的配置文件只有一半。然后全丢给AI看了，他说加个 `str()` 就好了。我照做后，确实好了

<img width="1095" height="422" alt="image" src="https://github.com/user-attachments/assets/530c4188-fa79-4c21-8b86-efeb0ceecd8c" />

而砍了一半的配置文件大概长这样：

<img width="577" height="220" alt="image" src="https://github.com/user-attachments/assets/18d05c48-35da-42f2-b9eb-d6f75f47c10d" />

https://gemini.google.com/share/a8cc4d58ae4c （第二、三段对话）

---

**下面是 AI 说的：**

根据你提供的原仓库源码，定位到了导致该报错的精准位置。

这个 Bug 出在 `games_ai/__init__.py` 文件的第 35 行左右，也就是插件初始化定义默认配置 `DEFAULT_CONFIG` 的地方。

### 报错根本原因

源码中使用了 `server.rtr("games_ai.system_message.default")` 来获取默认提示词。MCDR 的 `server.rtr()` 方法返回的是一个特殊的 **`RTextMCDRTranslation` 文本对象**，而不是单纯的字符串。当 MCDR 试图将这个包含文本对象的默认配置通过 `json.dump()` 写入 `config.json` 配置文件时，Python 的 `json` 库无法识别它，从而抛出了 `TypeError` 错误。

---

### 修复方法

你需要将该文本对象用 `str()` 包裹，强制转换为普通的 Python 字符串。

打开 `games_ai/__init__.py` 文件，找到以下代码块（约第 30-45 行）：

❌ **原错误代码：**

```python
    DEFAULT_CONFIG = {
        "prefix": "[GamesAI]",
        "permission": 3,
        "max_history": 10,
        "all_ai": {
            "<Your AI ID>":{
                "prompt": server.rtr("games_ai.system_message.default"),
                "ai_name": "[GamesAI]",
                "base_url": "<Your API Base URL>",
                "ai_model": "<Your AI Model>",
                "api_key": "<Your API Key>",
                "thinking": False,
            }
        },
        "default_ai": "<Your AI ID>"
    }

```

✔️ **修改后的正确代码（只需在 `prompt` 那一行加上 `str()`）：**

```python
    DEFAULT_CONFIG = {
        "prefix": "[GamesAI]",
        "permission": 3,
        "max_history": 10,
        "all_ai": {
            "<Your AI ID>":{
                "prompt": str(server.rtr("games_ai.system_message.default")),
                "ai_name": "[GamesAI]",
                "base_url": "<Your API Base URL>",
                "ai_model": "<Your AI Model>",
                "api_key": "<Your API Key>",
                "thinking": False,
            }
        },
        "default_ai": "<Your AI ID>"
    }

```

### 为什么这样改？

观察后续第 93 行左右的代码，作者在处理 `mcdr_lang` 时就很正确地使用了 `str(server.rtr(...))` 进行转换：

```python
mcdr_lang = str(server.rtr("games_ai.system_message.lang", lang=server.get_mcdr_language()))

```

但在编写 `DEFAULT_CONFIG` 时粗心漏掉了 `str()`。修改保存后，重新打包或直接放回 MCDR 的 `plugins` 文件夹中，服务器就能正常生成并加载配置文件了。